### PR TITLE
Update Dockerfile to support last version of image-match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.5
 MAINTAINER Alex Kern <alex@pavlovml.com>
 
 # deps
@@ -6,8 +6,8 @@ RUN apt-get update && \
     apt-get install -y libopenblas-dev gfortran && \
     pip install numpy && \
     pip install scipy && \
-    pip install scikit-image cairosvg elasticsearch flask gunicorn && \
-    pip install git+https://github.com/ascribe/image-match.git@0.2.1
+    pip install flask gunicorn && \
+    pip install image-match
 
 # install
 RUN mkdir -p /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY src .
 # run
 EXPOSE 80
 ENV PORT 80
-CMD gunicorn -w ${WORKER_COUNT:-4} wsgi:app
+CMD wget --retry-connrefused --tries=100 -q --wait=1 --spider elasticsearch:9200 && gunicorn -w ${WORKER_COUNT:-4} wsgi:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY src .
 # run
 EXPOSE 80
 ENV PORT 80
-CMD wget --retry-connrefused --tries=100 -q --wait=1 --spider elasticsearch:9200 && gunicorn -w ${WORKER_COUNT:-4} wsgi:app
+CMD gunicorn -w ${WORKER_COUNT:-4} wsgi:app

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,8 @@ run: build
 		-p $(PORT):80 \
 		-it $(DOCKER_TAG)
 
-devel: build kill
-	docker run -d \
-	    --name pavlov_elasticsearch \
-	    -p $(ELASTICSEARCH_PORT):9200 \
-	    elasticsearch
-	docker run -d \
-	    --name pavlov_match \
-	    -p $(PORT):80 \
-	    --link pavlov_elasticsearch:elasticsearch \
-	    pavlov/match
+devel: build
+	docker-compose up -d
 
 kill:
-	-docker kill pavlov_elasticsearch pavlov_match
-	-docker rm pavlov_elasticsearch pavlov_match
+	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: all build push run
+.PHONY: all build push run devel kill
 
 DOCKER_TAG ?= pavlov/match
 ELASTICSEARCH_URL ?=
 PORT ?= 8000
+ELASTICSEARCH_PORT ?= 59200
 
 all: run
 
@@ -17,3 +18,20 @@ run: build
 		-e ELASTICSEARCH_URL \
 		-p $(PORT):80 \
 		-it $(DOCKER_TAG)
+
+devel: build kill
+	docker run -d \
+	    --name pavlov_elasticsearch \
+	    -p $(ELASTICSEARCH_PORT):9200 \
+	    elasticsearch
+	# Wait until elasticsearch is running
+	wget --retry-connrefused --tries=10 -q --wait=1 --spider localhost:$(ELASTICSEARCH_PORT)
+	docker run -d \
+	    --name pavlov_match \
+	    -p $(PORT):80 \
+	    --link pavlov_elasticsearch:elasticsearch \
+	    pavlov/match
+
+kill:
+	-docker kill pavlov_elasticsearch pavlov_match
+	-docker rm pavlov_elasticsearch pavlov_match

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@ devel: build kill
 	    --name pavlov_elasticsearch \
 	    -p $(ELASTICSEARCH_PORT):9200 \
 	    elasticsearch
-	# Wait until elasticsearch is running
-	wget --retry-connrefused --tries=10 -q --wait=1 --spider localhost:$(ELASTICSEARCH_PORT)
 	docker run -d \
 	    --name pavlov_match \
 	    -p $(PORT):80 \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Adds an image signature to the database.
 
   The path to save the image to in the database. If another image already exists at the given path, it will be overwritten.
 
+* **metadata** *(default: None)*
+
+  An arbitrary JSON object featuring meta data to attach to the image.
+
 #### Example Response
 
 ```json

--- a/README.md
+++ b/README.md
@@ -16,12 +16,23 @@
 
 ## Getting Started
 
-If you already have elasticsearch running:
-    $ docker run -e ELASTICSEARCH_URL=https://daisy.us-west-1.es.amazonaws.com -it pavlov/match
+If you already have ElasticSearch running:
+```
+$ docker run -e ELASTICSEARCH_URL=https://daisy.us-west-1.es.amazonaws.com -it pavlov/match
+```
 
-If you want to run elasticsearch in another docker container and link it to our `pavlov/match` container (use the `-p` option to export the ports from the containers to the host):
-    $ docker run --name -p 59200:9200 my_elasticsearch_db elasticsearch
-    $ docker run --link -p 8888:80 my_elasticsearch_db:elasticsearch pavlov/match
+If you want to run ElasticSearch in another docker container and link it to our `pavlov/match` container (use the `-p` option to export the ports from the containers to the host):
+```
+$ docker run --name -p 59200:9200 my_elasticsearch_db elasticsearch
+$ docker run --link -p 8888:80 my_elasticsearch_db:elasticsearch pavlov/match
+```
+
+or, if you have [`docker-compose`](https://docs.docker.com/compose/) installed on your system, type:
+```
+$ docker-compose up
+```
+
+(All the commands can be run using `make`. Take a look to the `Makefile` to check the options.)
 
 Match is packaged as a Docker container ([pavlov/match](https://hub.docker.com/r/pavlov/match/) on Docker Hub), making it highly portable and scalable to billions of images. You can configure a few options using environment variables:
 
@@ -41,6 +52,7 @@ Match is packaged as a Docker container ([pavlov/match](https://hub.docker.com/r
 * **WORKER_COUNT** *(default: 4)*
 
   The number of gunicorn worker forks to maintain in each Docker container.
+
 
 ### One-command deployment with spread
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,22 @@
 
 ## Getting Started
 
+If you already have elasticsearch running:
     $ docker run -e ELASTICSEARCH_URL=https://daisy.us-west-1.es.amazonaws.com -it pavlov/match
+
+If you want to run elasticsearch in another docker container and link it to our `pavlov/match` container (use the `-p` option to export the ports from the containers to the host):
+    $ docker run --name -p 59200:9200 my_elasticsearch_db elasticsearch
+    $ docker run --link -p 8888:80 my_elasticsearch_db:elasticsearch pavlov/match
 
 Match is packaged as a Docker container ([pavlov/match](https://hub.docker.com/r/pavlov/match/) on Docker Hub), making it highly portable and scalable to billions of images. You can configure a few options using environment variables:
 
-* **ELASTICSEARCH_URL** *(required)*
+* **ELASTICSEARCH_URL** *(default: `http://elasticsearch`)*
 
   A URL pointing to the Elasticsearch database where image signatures are to be stored. If you don't want to host your own Elasticsearch cluster, consider using [AWS Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/). That's what we use.
+  Note: in order to allow containers linking, the default value is set to `http://elasticsearch`
 
 * **ELASTICSEARCH_INDEX** *(default: images)*
- 
+
   The index in the Elasticsearch database where image signatures are to be stored.
 
 * **ELASTICSEARCH_DOC_TYPE** *(default: images)*
@@ -35,12 +41,6 @@ Match is packaged as a Docker container ([pavlov/match](https://hub.docker.com/r
 * **WORKER_COUNT** *(default: 4)*
 
   The number of gunicorn worker forks to maintain in each Docker container.
-  
-### Setting up Elasticsearch
-
-If you're setting up Match for the first time on your Elasticsearch cluster, you'll have to create an index to store image signatures (default: `images`). Assuming Elasticsearch is running locally, it can be created by executing:
-
-    $ curl -XPUT 'http://localhost:9200/images/'
 
 ### One-command deployment with spread
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,5 @@ services:
             - elasticsearch
     elasticsearch:
         image: elasticsearch
-
+        ports:
+            - "59200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+    match:
+        build: .
+        ports:
+            - "8888:80"
+        links:
+            - elasticsearch
+    elasticsearch:
+        image: elasticsearch
+

--- a/src/match/server.py
+++ b/src/match/server.py
@@ -53,10 +53,14 @@ def get_image(url_field, file_field):
 @app.route('/add', methods=['POST'])
 def add_handler():
     path = request.form['filepath']
+    try:
+        metadata = json.loads(request.form['metadata'])
+    except KeyError:
+        metadata = None
     img, bs = get_image('url', 'image')
 
     old_ids = ids_with_path(path)
-    ses.add_image(path, img, bytestream=bs)
+    ses.add_image(path, img, bytestream=bs, metadata=metadata)
     delete_ids(old_ids)
 
     return json.dumps({

--- a/src/match/server.py
+++ b/src/match/server.py
@@ -104,7 +104,8 @@ def search_handler():
         'method': 'search',
         'result': [{
             'score': dist_to_percent(m['dist']),
-            'filepath': m['path']
+            'filepath': m['path'],
+            'metadata': m['metadata']
         } for m in matches]
     })
 

--- a/src/match/server.py
+++ b/src/match/server.py
@@ -10,11 +10,16 @@ import os
 
 
 app = Flask(__name__)
-es = Elasticsearch([os.environ.get('ELASTICSEARCH_URL', 'http://db')])
+es = Elasticsearch([os.environ.get('ELASTICSEARCH_URL',
+                                   'http://elasticsearch')])
 es_index = os.environ.get('ELASTICSEARCH_INDEX', 'images')
 es_doc_type = os.environ.get('ELASTICSEARCH_DOC_TYPE', 'images')
 ses = SignatureES(es, index=es_index, doc_type=es_doc_type)
 gis = ImageSignature()
+
+# Try to create the index and ignore IndexAlreadyExistsException
+# if the index already exists
+es.indices.create(index=es_index, ignore=400)
 
 # =============================================================================
 # Helpers

--- a/src/match/server.py
+++ b/src/match/server.py
@@ -8,8 +8,9 @@ import os
 # =============================================================================
 # Globals
 
+
 app = Flask(__name__)
-es = Elasticsearch([os.environ['ELASTICSEARCH_URL']])
+es = Elasticsearch([os.environ.get('ELASTICSEARCH_URL', 'http://db')])
 es_index = os.environ.get('ELASTICSEARCH_INDEX', 'images')
 es_doc_type = os.environ.get('ELASTICSEARCH_DOC_TYPE', 'images')
 ses = SignatureES(es, index=es_index, doc_type=es_doc_type)


### PR DESCRIPTION
In this PR:
- update `Dockerfile` to:
  - use the new [image-match](https://github.com/ascribe/image-match) release (port to Python3 and bug fixes)
  - use the official docker image for Python 3
  - remove unused dependencies
- add `metadata` support when adding and retrieving an image
- add `docker-compose` config file

(thanks to @TimDaub for some of the commits and @rhsimplex for his support on `image-match`)
