### PR TITLE
Clean up docker-compose.yml syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ $ docker run --link -p 8888:80 my_elasticsearch_db:elasticsearch pavlov/match
 
 or, if you have [`docker-compose`](https://docs.docker.com/compose/) installed on your system, type:
 ```
-$ docker-compose up
+$ docker-compose up -d
 ```
+
+(If `match` does not start, it probably cant connect to elasticsearch just yet, wait 20 seconds and try `docker-compose up -d`)
 
 (All the commands can be run using `make`. Take a look to the `Makefile` to check the options.)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,35 @@
 version: '2'
 services:
     match:
+        environment:
+            ELASTICSEARCH_URL: "http://match-elasticsearch:9200"
+            ELASTICSEARCH_INDEX: "images"
+            ELASTICSEARCH_DOC_TYPE: "images"
+            PORT: 80
+
         build: .
-        ports:
-            - "8888:80"
-        links:
-            - elasticsearch
+        container_name: match
+        expose:
+            - "80"
+        networks:
+            - matchnet
+
     elasticsearch:
         image: elasticsearch
+        container_name: match-elasticsearch
         ports:
-            - "59200:9200"
+            - "9200:9200"
+            - "9300:9300"
+        networks:
+            - matchnet
+
+
+    datastore:
+      image: redis:2
+      container_name: match-redis
+      networks:
+          - matchnet
+
+networks:
+    matchnet:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,6 @@ services:
         networks:
             - matchnet
 
-
-    datastore:
-      image: redis:2
-      container_name: match-redis
-      networks:
-          - matchnet
-
 networks:
     matchnet:
 


### PR DESCRIPTION
I found by simply setting the variables in the docker-compose.yml the whole stack was a lot easier to grock and a lot more reliable.

Small note added about `match` dropping out if its started before `elasticsearch` is ready to accept connections
