### PR TITLE
Added elasticsearch-client Version 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     pip install gunicorn==19.7.1 && \
     pip install flask==0.12.2 && \
     pip install image-match==1.1.2 && \
+    pip install 'elasticsearch>=6.0.0,<7.0.0' && \
     rm -rf /var/lib/apt/lists/*
 
 COPY server.py wait-for-it.sh /


### PR DESCRIPTION
This new elasticsearch client will enable it to work also with elasticsearch 6 clusters.