### PR TITLE
Update docker-compose.yml to specify elasticsearch image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     links:
     - elasticsearch
   elasticsearch:
-    image: elasticsearch
+    image: elasticsearch:6.4.2
     ports:
     - 9200:9200


### PR DESCRIPTION
[The `elasticsearch` image on Docker Hub](https://hub.docker.com/_/elasticsearch/) has no `latest` tag, which is what Docker will try to use if no tag is specified. This change specifies what the latest version/tag on Docker Hub is, currently `6.4.2`.

Fixes #32