### PR TITLE
Fixed the /list route arguments get issue

### DIFF
--- a/server.py
+++ b/server.py
@@ -136,10 +136,14 @@ def count_handler():
         'result': [count]
     })
 
-@app.route('/list', methods=['GET'])
+@app.route('/list', methods=['GET', 'POST'])
 def list_handler():
-    offset = max(int(request.args.get('offset', 0)), 0)
-    limit = max(int(request.args.get('limit', 20)), 0)
+    if request.method == 'GET':
+        offset = max(int(request.args.get('offset', 0)), 0)
+        limit = max(int(request.args.get('limit', 20)), 0)
+    else:
+        offset = max(int(request.form.get('offset', 0)), 0)
+        limit = max(int(request.form.get('limit', 20)), 0)
     paths = paths_at_location(offset, limit)
 
     return json.dumps({

--- a/server.py
+++ b/server.py
@@ -126,7 +126,7 @@ def compare_handler():
         'result': [{ 'score': score }]
     })
 
-@app.route('/count', methods=['GET'])
+@app.route('/count', methods=['GET', 'POST'])
 def count_handler():
     count = count_images()
     return json.dumps({
@@ -153,7 +153,7 @@ def list_handler():
         'result': paths
     })
 
-@app.route('/ping', methods=['GET'])
+@app.route('/ping', methods=['GET', 'POST'])
 def ping_handler():
     return json.dumps({
         'status': 'ok',

--- a/server.py
+++ b/server.py
@@ -138,8 +138,8 @@ def count_handler():
 
 @app.route('/list', methods=['GET'])
 def list_handler():
-    offset = max(int(request.form.get('offset', 0)), 0)
-    limit = max(int(request.form.get('limit', 20)), 0)
+    offset = max(int(request.args.get('offset', 0)), 0)
+    limit = max(int(request.args.get('limit', 20)), 0)
     paths = paths_at_location(offset, limit)
 
     return json.dumps({


### PR DESCRIPTION
The arguments given by a GET request on the /list route were not getting received by the elasicsearch, due to a wrong method call.