### PR TITLE
Make ports in docker-compose.yml not remotely accessible by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   match:
     image: dsys/match:latest
     ports:
-    - 8888:8888
+    - 127.0.0.1:8888:8888
     command: ["/wait-for-it.sh", "-t", "60", "elasticsearch:9200", "--", "gunicorn", "-b", "0.0.0.0:8888", "-w", "4", "server:app"]
     links:
     - elasticsearch
   elasticsearch:
     image: elasticsearch:6.4.2
     ports:
-    - 9200:9200
+    - 127.0.0.1:9200:9200


### PR DESCRIPTION
I just had my database wiped by a ["meow" hack](https://searchsecurity.techtarget.com/news/252486611/Meow-attacks-wipe-more-than-1000-exposed-databases) because it was publicly accessible, despite me blocking all ports on my machine, but apparently docker just ignores that and opens every relevant port for everyone to see...